### PR TITLE
Fix getting ASTs when constructing dynamic call graphs

### DIFF
--- a/src/dynapyt/analyses/CallGraph.py
+++ b/src/dynapyt/analyses/CallGraph.py
@@ -4,6 +4,7 @@ from ..utils.nodeLocator import get_node_by_location, get_parent_by_type
 
 class CallGraph(BaseAnalysis):
     def __init__(self):
+        super(CallGraph, self).__init__()
         self.graph = set()
 
     def pre_call(self, dyn_ast: str, iid: int):


### PR DESCRIPTION
This is a tiny PR that fixes an `AttributeError` when calling `self._get_ast(dyn_ast)` in the `pre_call` method of the `CallGraph` analysis. The fix is to call the constructor of `BaseAnalysis` to initliaze `self.asts = {}`. Otherwise, it's not possible to get ASTs of Python files in a project. 