### PR TITLE
Fix: Fix missing argument for function_exit hook

### DIFF
--- a/src/dynapyt/runtime.py
+++ b/src/dynapyt/runtime.py
@@ -386,7 +386,7 @@ def _func_exit_(dyn_ast, iid, name: str):
 
 def _return_(dyn_ast, iid, function_iid, function_name, return_val=None):
     call_if_exists('runtime_event', dyn_ast, iid)
-    result_high = call_if_exists('function_exit', dyn_ast, function_iid, function_name, return_val)
+    result_high = call_if_exists('function_exit', dyn_ast, iid, function_iid, function_name, return_val)
     result_low = call_if_exists('_return', dyn_ast, iid, return_val)
     if result_low != None:
         return result_low


### PR DESCRIPTION
The TraceAll analysis won't run because of a missing argument (`iid`) when calling the `function_exit` hook