### PR TITLE
Fix blacklist attributes

### DIFF
--- a/src/dynapyt/instrument/CodeInstrumenter.py
+++ b/src/dynapyt/instrument/CodeInstrumenter.py
@@ -36,7 +36,13 @@ class CodeInstrumenter(m.MatcherDecoratableTransformer):
         self.current_function = []
         self.selected_hooks = selected_hooks
         self.to_import = set()
-        self.blacklist = [
+
+        # Blacklisted attributes are appended to the end of the source code.
+        # Some programs depend on being able to parse these attributes so
+        # there should be an uninstrumented version in the file (e.g. the
+        # __version__ attribute may be parsed for the project's version upon
+        # installation).
+        self.blacklist_names = {
             "__file__",
             "__name__",
             "__doc__",
@@ -51,7 +57,15 @@ class CodeInstrumenter(m.MatcherDecoratableTransformer):
             "__all__",
             "__path__",
             "__docformat__",
-        ]
+            "__version__",
+            "__author__",
+            "__email__",
+            "__license__",
+        }
+        self.blacklist_name_objs = [m.Name(name) for name in self.blacklist_names]
+        
+        # Blacklisted nodes to append to the end of the file
+        self.blacklist_nodes = [cst.Newline(value="\n")]
 
     def __create_iid(self, node):
         location = self.get_metadata(PositionProvider, node)
@@ -196,6 +210,7 @@ class CodeInstrumenter(m.MatcherDecoratableTransformer):
             + dynapyt_imports
             + [get_ast]
             + [try_body]
+            + self.blacklist_nodes
         )
         return updated_node.with_changes(body=new_body)
 
@@ -215,7 +230,7 @@ class CodeInstrumenter(m.MatcherDecoratableTransformer):
     # Lowest level
     @call_if_not_inside(m.AssignTarget() | m.Import() | m.ImportFrom() | m.AnnAssign())
     def leave_Name(self, original_node, updated_node):
-        if updated_node.value in self.blacklist:
+        if updated_node.value in self.blacklist_names:
             return updated_node
         if ("boolean" in self.selected_hooks) and (
             updated_node.value in ["True", "False"]
@@ -855,6 +870,19 @@ class CodeInstrumenter(m.MatcherDecoratableTransformer):
         return call
 
     def leave_Assign(self, original_node, updated_node):
+        # Keep track of nodes of blacklisted attributes
+        if self.file_path.endswith("__init__.py") and m.matches(
+            original_node,
+            m.Assign(
+                targets=[
+                    m.AtLeastN(
+                        n=1, matcher=m.AssignTarget(target=m.OneOf(*self.blacklist_name_objs))
+                    )
+                ]
+            ),
+        ):
+            self.blacklist_nodes.append(original_node)
+            self.blacklist_nodes.append(cst.Newline(value="\n"))
         if "write" not in self.selected_hooks:
             return updated_node
         callee_name = cst.Name(value="_write_")

--- a/src/dynapyt/instrument/CodeInstrumenter.py
+++ b/src/dynapyt/instrument/CodeInstrumenter.py
@@ -881,7 +881,7 @@ class CodeInstrumenter(m.MatcherDecoratableTransformer):
                 ]
             ),
         ):
-            self.blacklist_nodes.append(original_node)
+            self.blacklist_nodes.append(cst.SimpleStatementLine(body=[original_node]))
             self.blacklist_nodes.append(cst.Newline(value="\n"))
         if "write" not in self.selected_hooks:
             return updated_node

--- a/src/dynapyt/instrument/instrument.py
+++ b/src/dynapyt/instrument/instrument.py
@@ -64,22 +64,6 @@ def instrument_file(file_path, selected_hooks):
     copied_file_path = re.sub(r"\.py$", ".py.orig", file_path)
     copyfile(file_path, copied_file_path)
 
-    if file_path.endswith("__init__.py"):
-        black_list = [
-            "__version__",
-            "__author__",
-            "__email__",
-            "__license__",
-            "__all__",
-        ]
-        additional = []
-        original_code = src.splitlines()
-        for l in original_code:
-            for b in black_list:
-                if l.startswith(b):
-                    additional.append(l)
-        instrumented_code = instrumented_code + "\n" + "\n".join(additional)
-
     with open(file_path, "w") as file:
         file.write(instrumented_code)
     iids.store()


### PR DESCRIPTION
Issue: https://github.com/sola-st/DynaPyt/issues/29

Currently, blacklisted attributes such as `__version__` and `__all__` are appended to the end of a file upon instrumentation, but will only copy one line of code per attribute. This results in values being cut off if they span multiple lines ([example](https://github.com/sola-st/DynaPyt/issues/29#issuecomment-1597402221)). That is fixed here.

We save the nodes of blacklisted attributes while traversing the CST, then append those nodes to the end of the module.

This was tested on the BeautifulSoup project and seems to work as intended.