### PR TITLE
Make locals and globals same when running analysis modules

### DIFF
--- a/src/dynapyt/run_analysis.py
+++ b/src/dynapyt/run_analysis.py
@@ -44,7 +44,7 @@ def run_analysis(entry: str, analyses: List[str], name: str = None):
         pass
     if entry.endswith(".py"):
         sys.argv = [entry]
-        exec(open(abspath(entry)).read())
+        exec(open(abspath(entry)).read(), globals())
     else:
         importlib.import_module(entry, "*")
     end_execution()


### PR DESCRIPTION
Fixes this error we've been getting:

```python
# test_MyAnalysis.py
my_var = 'hello world'

def my_func():
    print(my_var)

my_func()
``` 
```shell
python -m dynapyt.run_analysis --entry test_MyAnalysis.py --analysis dynapyt.analyses.MyAnalysis.MyAnalysis
``` 
```shell
Traceback (most recent call last):
  File "/Users/junholee/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/junholee/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/junholee/Documents/trying-os-projects/DynaPyt/.env/lib/python3.10/site-packages/dynapyt/run_analysis.py", line 64, in <module>
    run_analysis(args.entry, analyses, name)
  File "/Users/junholee/Documents/trying-os-projects/DynaPyt/.env/lib/python3.10/site-packages/dynapyt/run_analysis.py", line 47, in run_analysis
    exec(open(abspath(entry)).read())
  File "<string>", line 6, in <module>
  File "<string>", line 4, in my_func
NameError: name 'my_var' is not defined
``` 

Python keeps dictionaries for global and local properties. [At the module level, it is expected that the `locals()` dictionary and `globals()` dictionary are the same object](https://docs.python.org/3/library/functions.html#locals). The `exec()` function, by default, [runs the given code using the current locals() and globals() dictionaries](https://docs.python.org/3/library/functions.html#exec).

In `run_analysis.py`, we run `exec()` inside of a function, where `locals()` and `globals()` differ. Therefore, we run our test script with differing `locals()` and `globals()` dictionaries. This is what causes the namespace issue. It is fixed by adding a dictionary as an additional argument to `exec()`, which ["will be used for both the global and the local variables"](https://docs.python.org/3/library/functions.html#exec).

Why it's a problem if `locals()` and `globals()` are different at the module level: When you declare a variable at the module level, Python adds it to the `locals()` dictionary, expecting that this is equivalent to adding to the `globals()` dictionary. When you call a function, that function gets a fresh `locals()` dictionary and expects that the globally declared properties are accessible from `globals()`. If `locals()` and `globals()` are different at the module level, the globally declared variables aren't added to `globals()`, and the global variables are not accessible from inside functions.