### PR TITLE
Fixed issue with annotated assignments

### DIFF
--- a/tests/trace_single_hook/annotated_assignment/expected.txt
+++ b/tests/trace_single_hook/annotated_assignment/expected.txt
@@ -2,4 +2,8 @@ begin execution
 Writing 10 to [('a',)]
 read value 10
 Writing 10 to [('b',)]
+read value <class 'trace_single_hook.annotated_assignment.program.X'>
+Writing 10 to [('x',)]
+Writing <trace_single_hook.annotated_assignment.program.X object at <...>> to [('c',)]
+Writing hello to [('c', 'y')]
 end execution

--- a/tests/trace_single_hook/annotated_assignment/program.py
+++ b/tests/trace_single_hook/annotated_assignment/program.py
@@ -1,2 +1,9 @@
+class X:
+    def __init__(self):
+        self.x: int = 10
+
+
 a = 10
 b: int = a
+c = X()
+c.y: str = "hello"


### PR DESCRIPTION
Annotated assignments were not instrumented correctly, which resulted in program crashes.
Specifically assignments in which the target was not a name. For example, for
```python
foo.bar: int = 1
```
the left-hand side would be instrumented, which would cause an Exception, since you cannot annotate a function call.