### PR TITLE
Fix wrong argument order in run_analysis CLI

### DIFF
--- a/src/dynapyt/run_analysis.py
+++ b/src/dynapyt/run_analysis.py
@@ -127,4 +127,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     name = args.name
     analyses = args.analysis
-    run_analysis(args.entry, analyses, name, args.coverage)
+    run_analysis(
+        entry=args.entry,
+        analyses=analyses,
+        name=name,
+        coverage=args.coverage
+    )


### PR DESCRIPTION
The `coverage` argument was given to the `output_dir` parameter by mistake. I used named arguments to make sure this won't happen with future changes.