### PR TITLE
Fixed issue with the argument error in the `analyses` module

### DIFF
--- a/src/dynapyt/analyses/BranchCoverage.py
+++ b/src/dynapyt/analyses/BranchCoverage.py
@@ -2,7 +2,8 @@ from typing import Optional
 from .BaseAnalysis import BaseAnalysis
 
 class BranchCoverage(BaseAnalysis):
-    def __init__(self):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.branches = dict()
 
     def enter_control_flow(self, dyn_ast: str, iid: int, cond_value: bool) -> Optional[bool]:

--- a/src/dynapyt/analyses/CallGraph.py
+++ b/src/dynapyt/analyses/CallGraph.py
@@ -9,8 +9,8 @@ from inspect import getmodule
 
 
 class CallGraph(BaseAnalysis):
-    def __init__(self):
-        super(CallGraph, self).__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         logging.basicConfig(
             filename="dynapyt.json", format="%(message)s", level=logging.INFO
         )

--- a/src/dynapyt/analyses/Demo.py
+++ b/src/dynapyt/analyses/Demo.py
@@ -2,7 +2,8 @@ from typing import Optional
 from .BaseAnalysis import BaseAnalysis
 
 class Demo(BaseAnalysis):
-    def __init__(self):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.branches = dict()
 
     def enter_control_flow(self, dyn_ast: str, iid: int, cond_value: bool) -> Optional[bool]:

--- a/src/dynapyt/analyses/EventAnalysis.py
+++ b/src/dynapyt/analyses/EventAnalysis.py
@@ -1,8 +1,8 @@
 from .BaseAnalysis import BaseAnalysis
 
 class EventAnalysis(BaseAnalysis):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
     
     def runtime_event(self, dyn_ast, iid):
         print('.', end='')

--- a/src/dynapyt/analyses/KeyInListAnalysis.py
+++ b/src/dynapyt/analyses/KeyInListAnalysis.py
@@ -2,7 +2,8 @@
 from .BaseAnalysis import BaseAnalysis
 
 class KeyInListAnalysis(BaseAnalysis):
-    def __init__(self):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.threshold = 100
 
     def _in(self, dyn_ast, iid, left, right, result):

--- a/src/dynapyt/analyses/LiteralAnalysis.py
+++ b/src/dynapyt/analyses/LiteralAnalysis.py
@@ -2,8 +2,8 @@ from .BaseAnalysis import BaseAnalysis
 from typing import Any
 
 class LiteralAnalysis(BaseAnalysis):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
     
     def literal(self, dyn_ast: str, iid: int, value: Any) -> Any:
         print(str(iid) + ': Literal')

--- a/src/dynapyt/analyses/MLMemoryAnalysis.py
+++ b/src/dynapyt/analyses/MLMemoryAnalysis.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from .BaseAnalysis import BaseAnalysis
 
 class MLMemoryAnalysis(BaseAnalysis):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.in_ctrl_flow = []
         self.threshold = 3
         self.memory_leak = defaultdict(lambda: 0)

--- a/src/dynapyt/analyses/MemoryAccessAnalysis.py
+++ b/src/dynapyt/analyses/MemoryAccessAnalysis.py
@@ -3,8 +3,8 @@ from .BaseAnalysis import BaseAnalysis
 from typing import Any
 
 class MemoryAccessAnalysis(BaseAnalysis):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.danger_of_recursion = False
         logging.basicConfig(filename='output.log', format='%(message)s', encoding='utf-8', level=logging.INFO)
     

--- a/src/dynapyt/analyses/OnlyAddAnalysis.py
+++ b/src/dynapyt/analyses/OnlyAddAnalysis.py
@@ -1,8 +1,8 @@
 from .BaseAnalysis import BaseAnalysis
 
 class OnlyAddAnalysis(BaseAnalysis):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
     
     def add(self, dyn_ast, iid, left, opr, right):
         print(str(iid) + ': Add')

--- a/src/dynapyt/analyses/OperationAnalysis.py
+++ b/src/dynapyt/analyses/OperationAnalysis.py
@@ -2,8 +2,8 @@ from .BaseAnalysis import BaseAnalysis
 from typing import Any, List
 
 class OperationAnalysis(BaseAnalysis):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
     
     def operation(self, dyn_ast: str, iid: int, operator: str, operands: List[Any], result: Any) -> Any:
         print(str(iid) + ': Operation')

--- a/src/dynapyt/analyses/SimpleTaintAnalysis.py
+++ b/src/dynapyt/analyses/SimpleTaintAnalysis.py
@@ -5,8 +5,8 @@ from aiopg.connection import Cursor
 
 class SimpleTaintAnalysis(BaseAnalysis):
     
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.tainted = set()
         self.seen_source = False
         self.seen_sink = False

--- a/src/dynapyt/analyses/TraceAll.py
+++ b/src/dynapyt/analyses/TraceAll.py
@@ -11,8 +11,8 @@ class TraceAll(BaseAnalysis):
     .. include:: ../../../docs/hooks.md
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         root_logger = logging.getLogger()
         root_logger.setLevel(logging.INFO)
         handler = logging.FileHandler("output.log", "w", "utf-8")


### PR DESCRIPTION
The fix https://github.com/sola-st/DynaPyt/commit/8b3d771fd1d32e6e78879e1c733682b435fccd64 introduced another bug. It changed the `__init__()` interface of all analysis classes. For example, if we run DynaPyt with analysis `TraceAll`, it will crash with the message `TypeError: TraceAll.__init__() got an unexpected keyword argument 'output_dir'`

My solution is to add the `**kwargs` argument and call the `super().__init__(**kwargs)` when an analysis class has its own constructor.